### PR TITLE
rm gem name from external gemfile

### DIFF
--- a/bake/test/external.rb
+++ b/bake/test/external.rb
@@ -58,16 +58,20 @@ def clone_and_test(name, key, config)
 		
 		gemfile_paths = ["#{path}/Gemfile", "#{path}/gems.rb"]
 		gemfile_path = gemfile_paths.find{|path| File.exist?(path)}
-		
-		File.open(gemfile_path, "a") do |file| 
-			file.puts nil, "# Added by external testing:"
-			file.puts("gem #{name.to_s.dump}, path: '../../'")
-			
-			config[:extra]&.each do |line|
-				file.puts(line)
-			end
-		end
-		
+
+    File.open(gemfile_path, 'r+') do |file|
+      reg = Regexp.union(/gem "#{name.to_s}"/, /gem '#{name.to_s}'/)
+      name_excluded_lines = file.grep_v(reg)
+      file.seek(0)
+      file.puts(name_excluded_lines.join)
+      file.puts nil, "# Added by external testing:"
+      file.puts("gem #{name.to_s.dump}, path: '../../'")
+
+      config[:extra]&.each do |line|
+        file.puts(line)
+      end
+    end
+
 		system("bundle", "install", chdir: path)
 	end
 	


### PR DESCRIPTION
Hi! thank you for great gem!
I tried to work on [this issue](https://github.com/omniauth/omniauth/issues/1091), but when I specified devise as the downstream dependency codebase for omniauth, I got the following error.

config/external.yaml in omniauth

```yaml
devise:
  url: https://github.com/heartcombo/devise.git
  command: bundle exec rake test
```

```bash
≻ bundle exec bake test:external
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Cloning into 'external/devise'...
remote: Enumerating objects: 367, done.
remote: Counting objects: 100% (367/367), done.
remote: Compressing objects: 100% (307/307), done.
remote: Total 367 (delta 32), reused 146 (delta 20), pack-reused 0
Receiving objects: 100% (367/367), 226.55 KiB | 6.12 MiB/s, done.
Resolving deltas: 100% (32/32), done.
Your Gemfile lists the gem omniauth (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.

[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that omniauth (>= 0) should come from an unspecified source and source at `../..`
. Bundler cannot continue.

 #  from /Users/qwyng/omniauth/external/devise/Gemfile:42
 #  -------------------------------------------
 #  # Added by external testing:
 >  gem "omniauth", path: '../../'
 #  -------------------------------------------

[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that omniauth (>= 0) should come from an unspecified source and source at `../..`
. Bundler cannot continue.

 #  from /Users/qwyng/omniauth/external/devise/Gemfile:42
 #  -------------------------------------------
 #  # Added by external testing:
 >  gem "omniauth", path: '../../'
 #  -------------------------------------------
External tests devise failed!
```

Generated external/devise/Gemfile

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

gemspec

gem "rails", "~> 7.0.0"
gem "omniauth"
gem "omniauth-oauth2"
gem "rdoc"

gem "rails-controller-testing", github: "rails/rails-controller-testing"

gem "responders", "~> 3.0"

group :test do
  gem "nokogiri", "< 1.13"
  gem "omniauth-facebook"
  gem "omniauth-openid"
  gem "rexml"
  gem "timecop"
  gem "webrat", "0.7.3", require: false
  gem "mocha", "~> 1.1", require: false
end

platforms :ruby do
  gem "sqlite3", "~> 1.4"
end

# platforms :jruby do
#   gem "activerecord-jdbc-adapter"
#   gem "activerecord-jdbcsqlite3-adapter"
#   gem "jruby-openssl"
# end

# TODO:
# group :mongoid do
#   gem "mongoid", "~> 4.0.0"
# end

# Added by external testing:
gem "omniauth", path: '../../'
```

This PR adds a process to remove potentially duplicate Gemfile lines.
Gemfile generated as a result of testing with omniauth with this process added is as follows.

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

gemspec

gem "rails", "~> 7.0.0"
gem "omniauth-oauth2"
gem "rdoc"

gem "rails-controller-testing", github: "rails/rails-controller-testing"

gem "responders", "~> 3.0"

group :test do
  gem "nokogiri", "< 1.13"
  gem "omniauth-facebook"
  gem "omniauth-openid"
  gem "rexml"
  gem "timecop"
  gem "webrat", "0.7.3", require: false
  gem "mocha", "~> 1.1", require: false
end

platforms :ruby do
  gem "sqlite3", "~> 1.4"
end

# platforms :jruby do
#   gem "activerecord-jdbc-adapter"
#   gem "activerecord-jdbcsqlite3-adapter"
#   gem "jruby-openssl"
# end

# TODO:
# group :mongoid do
#   gem "mongoid", "~> 4.0.0"
# end

# Added by external testing:
gem "omniauth", path: '../../'
```

